### PR TITLE
Remove Forms 

### DIFF
--- a/_deceased-cpf-estate-monies/forms.md
+++ b/_deceased-cpf-estate-monies/forms.md
@@ -9,9 +9,6 @@ Forms
 
 **Forms For Public Trustee**<br>
 
-[Form 7 - Discrepancies in Documents](/files/Forms_Page/DiscrepanciesinDocuments(Form7).pdf){:target="_blank"}(78 KB)
-
-[Form 10 - Application for CPF Monies Less Than or Equal to $100](/files/Forms_Page/form10.pdf){:target="_blank"}(223KB)
 
 [Form 12 - Declaration Form (CPF monies) for funeral expenses](/files/Forms_Page/Declarationform(CPFMonies)forfuneralexpenses(Form12).pdf){:target="_blank"}(220KB)
 
@@ -28,7 +25,5 @@ Forms
 [Form 18 - Renunciation &amp; Indemnity Form](/files/Forms_Page/Form18.pdf){:target="_blank"}(139KB)
 
 [Form 19 - Letter of Declaration for funeral receipts](/files/Forms_Page/Form%2019_Letter%20of%20Declaration%20for%20Funeral%20Receipts.pdf){:target="_blank"}(122 KB)
-
-[Form 20 - Consent Form for Appointment of Beneficiary Representative](/files/Forms_Page/Form20.pdf){:target="_blank"}(139 KB)
 
 [Form 21 - Application For Distribution of a Deceased Person’s Un-Nominated CPF Monies through a Beneficiary Represenatative](/files/Forms_Page/Form21_BRApplicationForm.pdf){:target="_blank"}(260 KB)

--- a/_deceased-cpf-estate-monies/forms.md
+++ b/_deceased-cpf-estate-monies/forms.md
@@ -16,8 +16,6 @@ Forms
 
 [Form 15 - Letter of Authorisation &amp; Indemnity for payment to Third party Bank Account](/files/Forms_Page/form15.pdf){:target="_blank"}(259 KB)
 
-*[Forms 15A and 15B/C are replaced by Form 15. With effect from 17 October 2020, Form 15 is only required for payments made to third-party's bank account.]*
-
 [Form 16 - Declaration of Relationship with the Deceased ](/files/Forms_Page/Form16_DeclarationofRelationshipwithDeceased.pdf){:target="_blank"}(120 KB)
 
 [Form 17 - Declaration of Services rendered to minor beneficiaries](/files/Forms_Page/DeclarationofServicesrenderedtoMinor(Form17).pdf){:target="_blank"}(139 KB)


### PR DESCRIPTION
Form 10, 7 and 20 are removed from the site. Also, removed the liner “*[Forms 15A and 15B/C are replaced by Form 15. With effect from 17 October 2020, Form 15 is only required for payments made to third-party's bank account.]*” 